### PR TITLE
Bump node package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.4.7",
-    "mixpanel": "^0.6.0",
+    "mixpanel": "^0.10.2",
     "mixpanel-browser": "^2.29.1"
   },
   "repository": {


### PR DESCRIPTION
The test failures we discussed were caused by the fact mixpanel browser library switched to using https, and out mocks were catching http URLs.
This bumps the nodejs module to align behaviors and get both of them using https.

See https://github.com/balena-io-modules/resin-event-log/pull/11

Change-type: minor
Signed-off-by: Roman Mazur <roman@balena.io>